### PR TITLE
feat(frontend): add Tailwind Typography docs

### DIFF
--- a/app/global.css
+++ b/app/global.css
@@ -2,6 +2,7 @@
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
 @import "tw-animate-css";
+@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:is(.dark *));
 

--- a/content/docs/frontend/meta.json
+++ b/content/docs/frontend/meta.json
@@ -6,6 +6,7 @@
     "shadcn",
     "lucide",
     "motion",
+    "typography",
     "tiptap",
     "sidebar-setup",
     "..."

--- a/content/docs/frontend/typography.mdx
+++ b/content/docs/frontend/typography.mdx
@@ -1,0 +1,55 @@
+---
+title: Tailwind Typography
+description: Guide to installing and using the Tailwind CSS Typography plugin.
+---
+
+import { Step, Steps } from 'fumadocs-ui/components/steps';
+import { CodeTabs } from '@/components/animate-ui/components/code-tabs';
+
+More information on the Tailwind CSS Typography plugin is available on the [official repository](https://github.com/tailwindlabs/tailwindcss-typography) and the [demo site](https://tailwindcss-typography.vercel.app/).
+
+## TLDR
+
+<CodeTabs lang="bash" codes={{
+    bash: `pnpm add -D @tailwindcss/typography`,
+  }} />
+
+<Steps>
+<Step>
+## 1. Installation
+
+Install `@tailwindcss/typography` using your preferred package manager.
+
+<CodeTabs lang="bash" codes={{
+    pnpm: `pnpm add -D @tailwindcss/typography`,
+    yarn: `yarn add -D @tailwindcss/typography`,
+    npm: `npm install -D @tailwindcss/typography`,
+    bun: `bun add -d @tailwindcss/typography`,
+  }} />
+</Step>
+
+<Step>
+## 2. Configure plugin
+
+Add the plugin directive to your global CSS file.
+
+<CodeTabs lang="css" codes={{
+    css: `@import "tailwindcss";
+@import "tw-animate-css";
+@plugin "@tailwindcss/typography";`,
+  }} />
+</Step>
+
+<Step>
+## 3. Basic usage
+
+Use the `prose` classes to style generated HTML content.
+
+<CodeTabs lang="html" codes={{
+    html: `<article class="prose lg:prose-xl">
+  <h1>Garlic bread with cheese: What the science tells us</h1>
+  <p>For years parents have espoused the health benefits of eating garlic bread with cheese to their children...</p>
+</article>`,
+  }} />
+</Step>
+</Steps>

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "devDependencies": {
     "@shikijs/transformers": "^3.3.0",
     "@tailwindcss/postcss": "^4.1.5",
+    "@tailwindcss/typography": "^0.5.11",
     "@types/mdx": "^2.0.13",
     "@types/node": "22.15.3",
     "@types/react": "^19.1.2",


### PR DESCRIPTION
## Summary
- document Tailwind CSS Typography usage in frontend guide
- enable typography plugin in global styles
- register page in frontend docs

## Testing
- `pnpm add -D @tailwindcss/typography` *(fails: GET https://registry.npmjs.org/@tailwindcss%2Ftypography 403 Forbidden)*
- `pnpm build` *(fails: Failed to fetch font `Inter`: https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5d474ab4832faf49f6e8d5fd23fd