### PR TITLE
docs: expand supabase setup guide

### DIFF
--- a/content/docs/backend/supabase.mdx
+++ b/content/docs/backend/supabase.mdx
@@ -1,6 +1,477 @@
 ---
 title: Supabase
-description: How to install and use the Supabase database in React projects using pnpm.
+description: Learn how to install, configure, and generate types for the Supabase client in a Next.js App Router project.
 ---
 
-This is a test
+## Installation
+
+```bash
+pnpm dlx shadcn@latest add @supabase/supabase-client-nextjs
+```
+
+Install the block dependencies with your preferred package manager:
+
+```bash
+# npm
+npm install
+
+# pnpm
+pnpm install
+
+# yarn
+yarn install
+
+# bun
+bun install
+```
+
+## Folder structure
+
+The block scaffolds a Supabase setup under `lib/supabase` with three entry points:
+
+```
+lib/
+  supabase/
+    client.ts
+    middleware.ts
+    server.ts
+```
+
+### `middleware.ts`
+
+```ts
+import { createServerClient } from '@supabase/ssr'
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function updateSession(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({
+    request,
+  })
+
+  // With Fluid compute, don't put this client in a global environment
+  // variable. Always create a new one on each request.
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll()
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+          supabaseResponse = NextResponse.next({
+            request,
+          })
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, options)
+          )
+        },
+      },
+    }
+  )
+
+  // Do not run code between createServerClient and
+  // supabase.auth.getClaims(). A simple mistake could make it very hard to debug
+  // issues with users being randomly logged out.
+
+  // IMPORTANT: If you remove getClaims() and you use server-side rendering
+  // with the Supabase client, your users may be randomly logged out.
+  const { data } = await supabase.auth.getClaims()
+  const user = data?.claims
+
+  if (
+    !user &&
+    !request.nextUrl.pathname.startsWith('/login') &&
+    !request.nextUrl.pathname.startsWith('/auth')
+  ) {
+    // no user, potentially respond by redirecting the user to the login page
+    const url = request.nextUrl.clone()
+    url.pathname = '/auth/login'
+    return NextResponse.redirect(url)
+  }
+
+  // IMPORTANT: You *must* return the supabaseResponse object as it is.
+  // If you're creating a new response object with NextResponse.next() make sure to:
+  // 1. Pass the request in it, like so:
+  //    const myNewResponse = NextResponse.next({ request })
+  // 2. Copy over the cookies, like so:
+  //    myNewResponse.cookies.setAll(supabaseResponse.cookies.getAll())
+  // 3. Change the myNewResponse object to fit your needs, but avoid changing
+  //    the cookies!
+  // 4. Finally:
+  //    return myNewResponse
+  // If this is not done, you may be causing the browser and server to go out
+  // of sync and terminate the user's session prematurely!
+
+  return supabaseResponse
+}
+```
+
+### `client.ts`
+
+```ts
+import { createBrowserClient } from '@supabase/ssr'
+
+export function createClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!
+  )
+}
+```
+
+### `server.ts`
+
+```ts
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+/**
+ * If using Fluid compute: Don't put this client in a global variable. Always create a new client within each
+ * function when using it.
+ */
+export async function createClient() {
+  const cookieStore = await cookies()
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll()
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            )
+          } catch {
+            // The `setAll` method was called from a Server Component.
+            // This can be ignored if you have middleware refreshing
+            // user sessions.
+          }
+        },
+      },
+    }
+  )
+}
+```
+
+## Usage
+
+This block installs a Supabase client for connecting your Next.js project to Supabase. It's designed for use with the App Router and fully supports server-side rendering (SSR).
+
+If you've already set up your Supabase client—either using the `npx create-next-app -e with-supabase` template or another method—you can continue using your existing setup.
+
+### Getting started
+
+After installing the block, you'll have the following environment variables in your `.env.local` file:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY=
+```
+
+If you're using supabase.com, you can find these values in the Connect modal under **App Frameworks** or in your project's **API** settings.
+
+If you're using a local instance of Supabase, you can find these values by running `supabase start` or `supabase status` (if you already have it running).
+
+This Supabase client is built for SSR with the Next.js App Router. If you're building a React SPA, use the React SPA client instead.
+
+## Generating TypeScript types
+
+Supabase APIs are generated from your database, which means that we can use database introspection to generate type-safe API definitions.
+
+### Generating types from the project dashboard
+
+Supabase allows you to generate and download TypeScript types directly from the project dashboard.
+
+### Generating types using the Supabase CLI
+
+The Supabase CLI is a single binary Go application that provides everything you need to set up a local development environment.
+
+Install the CLI (minimum version `v1.8.1`):
+
+```bash
+npm i supabase@">=1.8.1" --save-dev
+```
+
+Log in with your Personal Access Token:
+
+```bash
+npx supabase login
+```
+
+Before generating types, ensure you initialize your Supabase project:
+
+```bash
+npx supabase init
+```
+
+Generate types for your project to produce the `database.types.ts` file:
+
+```bash
+npx supabase gen types typescript --project-id "$PROJECT_REF" --schema public > database.types.ts
+```
+
+For local development:
+
+```bash
+npx supabase gen types typescript --local > database.types.ts
+```
+
+These types are generated from your database schema. Given a table `public.movies`, the generated types will look like:
+
+```sql
+create table public.movies (
+  id bigint generated always as identity primary key,
+  name text not null,
+  data jsonb null
+);
+```
+
+```ts
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+export interface Database {
+  public: {
+    Tables: {
+      movies: {
+        Row: {
+          // the data expected from .select()
+          id: number
+          name: string
+          data: Json | null
+        }
+        Insert: {
+          // the data to be passed to .insert()
+          id?: never // generated columns must not be supplied
+          name: string // `not null` columns with no default must be supplied
+          data?: Json | null // nullable columns can be omitted
+        }
+        Update: {
+          // the data to be passed to .update()
+          id?: never
+          name?: string // `not null` columns are optional on .update()
+          data?: Json | null
+        }
+      }
+    }
+  }
+}
+```
+
+### Using TypeScript type definitions
+
+You can supply the type definitions to `supabase-js` like so:
+
+```ts
+import { createClient } from '@supabase/supabase-js'
+import { Database } from './database.types'
+
+const supabase = createClient<Database>(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_PUBLISHABLE_KEY
+)
+```
+
+### Helper types for tables and joins
+
+You can use helper types to make the generated TypeScript types easier to work with. For example, use `type-fest` to override view column definitions:
+
+```ts
+import { MergeDeep } from 'type-fest'
+import { Database as DatabaseGenerated } from './database-generated.types'
+export { Json } from './database-generated.types'
+
+export type Database = MergeDeep<
+  DatabaseGenerated,
+  {
+    public: {
+      Views: {
+        movies_view: {
+          Row: {
+            // id is a primary key in public.movies, so it must be `not null`
+            id: number
+          }
+        }
+      }
+    }
+  }
+>
+```
+
+To use `MergeDeep`, enable `compilerOptions.strictNullChecks` in your `tsconfig.json`.
+
+### Enhanced type inference for JSON fields
+
+Starting from `supabase-js` `v2.48.0`, you can define custom types for JSON fields and get enhanced type inference when using JSON selectors.
+
+#### Defining custom JSON types
+
+```ts
+import { MergeDeep } from 'type-fest'
+import { Database as DatabaseGenerated } from './database-generated.types'
+
+type CustomJsonType = {
+  foo: string
+  bar: { baz: number }
+  en: 'ONE' | 'TWO' | 'THREE'
+}
+
+export type Database = MergeDeep<
+  DatabaseGenerated,
+  {
+    public: {
+      Tables: {
+        your_table: {
+          Row: {
+            data: CustomJsonType | null
+          }
+        }
+      }
+      Views: {
+        your_view: {
+          Row: {
+            data: CustomJsonType | null
+          }
+        }
+      }
+    }
+  }
+>
+```
+
+#### Type-safe JSON querying
+
+```ts
+const res = await client.from('your_table').select('data->bar->baz, data->en, data->bar')
+if (res.data) {
+  console.log(res.data)
+  // TypeScript infers the shape of your JSON data:
+  // [
+  //   {
+  //     baz: number
+  //     en: 'ONE' | 'TWO' | 'THREE'
+  //     bar: { baz: number }
+  //   }
+  // ]
+}
+```
+
+The type inference automatically handles the difference between `->` (returns JSON) and `->>` (returns text) operators, ensuring your TypeScript types match the runtime behavior.
+
+You can also override the type of an individual successful response if needed:
+
+```ts
+const { data } = await supabase.from('countries').select().overrideTypes<Array<{ id: string }>>()
+const { data: merged } = await supabase
+  .from('countries')
+  .select()
+  .overrideTypes<Array<{ id: string }>, { merge: false }>()
+const { data: single } = await supabase.from('countries').select().single().overrideTypes<{ id: string }>()
+```
+
+### Type shorthands
+
+The generated types provide shorthands for accessing tables and enums:
+
+```ts
+import { Database, Tables, Enums } from './database.types'
+
+let movie: Tables<'movies'>
+```
+
+### Response types for complex queries
+
+`supabase-js` always returns a `data` object (for success) and an `error` object (for unsuccessful requests). Helper types provide the result types from any query, including nested types for database joins.
+
+Given a schema with a relation between cities and countries:
+
+```sql
+create table countries (
+  "id" serial primary key,
+  "name" text
+);
+create table cities (
+  "id" serial primary key,
+  "name" text,
+  "country_id" int references "countries"
+);
+```
+
+```ts
+import { QueryResult, QueryData, QueryError } from '@supabase/supabase-js'
+
+const countriesWithCitiesQuery = supabase.from('countries').select(`
+  id,
+  name,
+  cities (
+    id,
+    name
+  )
+`)
+
+type CountriesWithCities = QueryData<typeof countriesWithCitiesQuery>
+const { data, error } = await countriesWithCitiesQuery
+if (error) throw error
+const countriesWithCities: CountriesWithCities = data
+```
+
+### Update types automatically with GitHub Actions
+
+Keep your type definitions in sync with your database by scheduling a GitHub Action:
+
+```json
+{
+  "scripts": {
+    "update-types": "npx supabase gen types --lang=typescript --project-id \"$PROJECT_REF\" > database.types.ts"
+  }
+}
+```
+
+Create `.github/workflows/update-types.yml`:
+
+```yaml
+name: Update database types
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      PROJECT_REF: <your-project-id>
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm run update-types
+      - name: check for file changes
+        id: git_status
+        run: |
+          echo "status=$(git status -s)" >> $GITHUB_OUTPUT
+      - name: Commit files
+        if: ${{contains(steps.git_status.outputs.status, ' ')}}
+        run: |
+          git add database.types.ts
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "Update database types" -a
+      - name: Push changes
+        if: ${{contains(steps.git_status.outputs.status, ' ')}}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+```
+
+Alternatively, use the community-supported `generate-supabase-db-types-github-action` to automate type generation.


### PR DESCRIPTION
## Summary
- replace the Supabase backend guide with installation steps, folder structure details, and usage instructions for the Supabase Next.js block
- document generating Supabase TypeScript types and automating updates via the CLI and GitHub Actions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fc15583130832fa00d01d704e83f48